### PR TITLE
Commented out the add_header so secret token is not sent in response 

### DIFF
--- a/nginx.sample.conf
+++ b/nginx.sample.conf
@@ -107,7 +107,9 @@ http {
       proxy_set_header  X-Real-IP  $remote_addr;
       proxy_set_header  Host  $host;
       proxy_set_header X-3scale-proxy-secret-token $secret_token;
-      add_header X-3scale-proxy-secret-token $secret_token;
+      
+      ##This line should only be added to debug the secret token because the header will be seen by the api caller. 
+      ##add_header X-3scale-proxy-secret-token $secret_token;
 
       post_action /out_of_band_authrep_action;
     }


### PR DESCRIPTION
back to api caller.

3scale Support Forum with issue and resolution: https://support.3scale.net/forum/topics/protecting-access-to-my-api-backend-while-using-nginx-proxy#new_post
