### PR TITLE
Use latest rockspec version from leafo/heroku-openresty

### DIFF
--- a/package.rockspec
+++ b/package.rockspec
@@ -1,3 +1,3 @@
 dependencies = {
-	"https://raw.github.com/leafo/heroku-openresty/master/heroku-openresty-dev-1.rockspec"
+	"https://raw.github.com/leafo/heroku-openresty/master/heroku-openresty-dev-2.rockspec"
 }


### PR DESCRIPTION
Switch to the latest rockspec version from https://github.com/leafo/heroku-openresty
The version named `heroku-openresty-dev-1.rockspec` doesn't work anymore because it doesn't support the newer Heroku application stacks. See here for more info: https://github.com/leafo/heroku-openresty/pull/8
